### PR TITLE
add clojure, fennel and shell

### DIFF
--- a/lua/kommentary/config.lua
+++ b/lua/kommentary/config.lua
@@ -5,6 +5,7 @@ This module contains the mappings of comment strings to filetypes, as well as
 convenience functions for retrieving configuration parameters.
 ]]
 local default = {"//", {"/*", "*/"}}
+local shell = {"#", false}
 
 --[[--
 Set up keymappings.
@@ -53,7 +54,10 @@ local config_table = {
     ["swift"] = default,
     ["vim"] = {"\"", false},
     ["clojure"] = {";", {"(comment ", " )"}},
-    ["fennnel"] = {";", false}
+    ["fennnel"] = {";", false},
+    ["bash"] = shell,
+    ["fish"] = shell,
+    ["zsh"] = shell
 }
 
 --[[--

--- a/lua/kommentary/config.lua
+++ b/lua/kommentary/config.lua
@@ -53,7 +53,7 @@ local config_table = {
     ["swift"] = default,
     ["vim"] = {"\"", false},
     ["clojure"] = {";", {"(comment ", " )"}},
-    ["fennnel"] = {";"}
+    ["fennnel"] = {";", false}
 }
 
 --[[--

--- a/lua/kommentary/config.lua
+++ b/lua/kommentary/config.lua
@@ -52,6 +52,8 @@ local config_table = {
     ["rust"] = default,
     ["swift"] = default,
     ["vim"] = {"\"", false},
+    ["clojure"] = {";", {"(comment ", " )"}},
+    ["fennnel"] = {";"}
 }
 
 --[[--

--- a/lua/kommentary/config.lua
+++ b/lua/kommentary/config.lua
@@ -5,7 +5,6 @@ This module contains the mappings of comment strings to filetypes, as well as
 convenience functions for retrieving configuration parameters.
 ]]
 local default = {"//", {"/*", "*/"}}
-local shell = {"#", false}
 
 --[[--
 Set up keymappings.
@@ -38,13 +37,13 @@ first field can also be false, if a language always requires a pre- and suffix.
 Newlines are not allowed, since they can't be matched when commenting out.
 ]]
 local config_table = {
-    ["bash"] = shell,
+    ["bash"] = {"#", false},
     ["c"] = default,
     ["clojure"] = {";", {"(comment ", " )"}},
     ["cpp"] = default,
     ["cs"] = default,
     ["fennnel"] = {";", false},
-    ["fish"] = shell,
+    ["fish"] = {"#", false},
     ["go"] = default,
     ["java"] = default,
     ["javascript"] = default,
@@ -57,7 +56,7 @@ local config_table = {
     ["rust"] = default,
     ["swift"] = default,
     ["vim"] = {"\"", false},
-    ["zsh"] = shell
+    ["zsh"] = {"#", false}
 }
 
 --[[--

--- a/lua/kommentary/config.lua
+++ b/lua/kommentary/config.lua
@@ -38,9 +38,13 @@ first field can also be false, if a language always requires a pre- and suffix.
 Newlines are not allowed, since they can't be matched when commenting out.
 ]]
 local config_table = {
+    ["bash"] = shell,
     ["c"] = default,
+    ["clojure"] = {";", {"(comment ", " )"}},
     ["cpp"] = default,
     ["cs"] = default,
+    ["fennnel"] = {";", false},
+    ["fish"] = shell,
     ["go"] = default,
     ["java"] = default,
     ["javascript"] = default,
@@ -53,10 +57,6 @@ local config_table = {
     ["rust"] = default,
     ["swift"] = default,
     ["vim"] = {"\"", false},
-    ["clojure"] = {";", {"(comment ", " )"}},
-    ["fennnel"] = {";", false},
-    ["bash"] = shell,
-    ["fish"] = shell,
     ["zsh"] = shell
 }
 


### PR DESCRIPTION
https://clojuredocs.org/clojure.core/comment
> ;; What is inside the (comment ...) form is not completely ignored.  Clojure
> ;; still tries to use the normal reader to read it, so it must consist of
> ;; a sequence of readable forms with balanced parens, braces, square brackets,
> ;; with no unreadable elements.

I'm not sure if we should add multiline comments in this case
