### PR TITLE
Use commentstring  as fallback

### DIFF
--- a/lua/kommentary/config.lua
+++ b/lua/kommentary/config.lua
@@ -101,7 +101,7 @@ function M.get_config(filetype)
         filetype = vim.bo.filetype
     end
     if not M.has_filetype(filetype) then
-        return use_fallback and M.config_from_commentstring(vim.bo.commentstring) or default
+        return M.config_from_commentstring(vim.bo.commentstring)
     end
     return M.config[filetype]
 end

--- a/lua/kommentary/config.lua
+++ b/lua/kommentary/config.lua
@@ -71,6 +71,25 @@ function M.has_filetype(filetype)
     return M.config[filetype] ~= nil
 end
 
+function M.config_from_commentstring(commentstring)
+    if commenstring == "/*%s*/" then return default end
+
+    local placeholder = '%s'
+    local where = commentstring:find(util.escape_pattern(placeholder))
+
+    if not where then
+        return default
+    else
+        where = where - 1
+    end
+    if where + #placeholder  == #commentstring then
+        return { commentstring:sub(1, -#placeholder-1), false }
+    end
+
+    return { false, { commentstring:sub(1, where),  commentstring:sub(where + #placeholder + 1, -1) } }
+end
+
+
 --[[--
 Get the full config for the given filetype.
 @tparam string filetype Filetype to retrieve configuration for,
@@ -81,11 +100,13 @@ Get the full config for the given filetype.
 	Full configuration for filetype
 ]]
 function M.get_config(filetype)
+    local use_fallback = false
     if filetype == 0 then
         filetype = vim.bo.filetype
+        use_fallback = true
     end
     if not M.has_filetype(filetype) then
-        return default
+        return use_fallback and M.config_from_commentstring(vim.bo.commentstring) or default
     end
     return M.config[filetype]
 end

--- a/lua/kommentary/config.lua
+++ b/lua/kommentary/config.lua
@@ -82,12 +82,10 @@ function M.config_from_commentstring(commentstring)
     end
     where = where - 1
     if where + #placeholder == #commentstring then
-        return { commentstring:sub(1, -#placeholder-1), false }
+        return {commentstring:sub(1, -#placeholder-1), false}
     end
-
-    return { false, { commentstring:sub(1, where),  commentstring:sub(where + #placeholder + 1, -1) } }
+    return {false, {commentstring:sub(1, where),  commentstring:sub(where + #placeholder + 1, -1)}}
 end
-
 
 --[[--
 Get the full config for the given filetype.

--- a/lua/kommentary/config.lua
+++ b/lua/kommentary/config.lua
@@ -73,10 +73,8 @@ end
 
 function M.config_from_commentstring(commentstring)
     if commenstring == "/*%s*/" then return default end
-
     local placeholder = '%s'
     local where = commentstring:find(util.escape_pattern(placeholder))
-
     if not where then
         return default
     end

--- a/lua/kommentary/config.lua
+++ b/lua/kommentary/config.lua
@@ -82,7 +82,7 @@ function M.config_from_commentstring(commentstring)
     else
         where = where - 1
     end
-    if where + #placeholder  == #commentstring then
+    if where + #placeholder == #commentstring then
         return { commentstring:sub(1, -#placeholder-1), false }
     end
 

--- a/lua/kommentary/config.lua
+++ b/lua/kommentary/config.lua
@@ -79,9 +79,8 @@ function M.config_from_commentstring(commentstring)
 
     if not where then
         return default
-    else
-        where = where - 1
     end
+    where = where - 1
     if where + #placeholder == #commentstring then
         return { commentstring:sub(1, -#placeholder-1), false }
     end

--- a/lua/kommentary/config.lua
+++ b/lua/kommentary/config.lua
@@ -99,10 +99,8 @@ Get the full config for the given filetype.
 	Full configuration for filetype
 ]]
 function M.get_config(filetype)
-    local use_fallback = false
     if filetype == 0 then
         filetype = vim.bo.filetype
-        use_fallback = true
     end
     if not M.has_filetype(filetype) then
         return use_fallback and M.config_from_commentstring(vim.bo.commentstring) or default


### PR DESCRIPTION
This way users don't need to set the comment by hand cause most of the time it's defined in a plugin for language. 