### PR TITLE
Implemented callback in kommentary.go()

### DIFF
--- a/lua/kommentary/config.lua
+++ b/lua/kommentary/config.lua
@@ -24,9 +24,11 @@ Sets up <Plug>KommentaryLine, which is what you should use for commenting out si
 @treturn nil
 ]]
 function M.setup()
-    vim.api.nvim_set_keymap('n', '<Plug>Kommentary', 'v:lua.kommentary.toggle_comment()', { noremap = true, expr = true })
-    vim.api.nvim_set_keymap('n', '<Plug>KommentaryLine', '<cmd>call v:lua.kommentary.toggle_comment("single_line")<cr>', { noremap = true, silent = true })
-    vim.api.nvim_set_keymap('v', '<Plug>KommentaryVisual', '<cmd>call v:lua.kommentary.toggle_comment("visual")<cr>', { noremap = true, silent = true })
+    local modes = util.enum({"line", "visual", "motion", "init"})
+    vim.api.nvim_set_keymap('n', '<Plug>Kommentary', 'v:lua.kommentary.go(' .. modes.init .. ')', { noremap = true, expr = true })
+    vim.api.nvim_set_keymap('n', '<Plug>KommentaryLine', '<cmd>call v:lua.kommentary.go(' .. modes.line .. ')<cr>', { noremap = true, silent = true })
+    vim.api.nvim_set_keymap('v', '<Plug>KommentaryVisual', '<cmd>call v:lua.kommentary.go(' .. modes.visual .. ')<cr>', { noremap = true, silent = true })
+    vim.api.nvim_set_keymap('v', '<Plug>KommentaryVisualSingles', '<cmd>lua require("kommentary");kommentary.go(' .. modes.visual .. ', ' .. "{kommentary.toggle_comment_singles}" .. ')<cr>', { noremap = true, silent = false })
 end
 
 --[[--

--- a/lua/kommentary/config.lua
+++ b/lua/kommentary/config.lua
@@ -24,11 +24,37 @@ Sets up <Plug>KommentaryLine, which is what you should use for commenting out si
 @treturn nil
 ]]
 function M.setup()
+    --[[ These are the available modes that can be passed to kommentary.go, we
+    need to choose the appropriate one depending on the mode of the mapping ]]
     local modes = util.enum({"line", "visual", "motion", "init"})
-    vim.api.nvim_set_keymap('n', '<Plug>Kommentary', 'v:lua.kommentary.go(' .. modes.init .. ')', { noremap = true, expr = true })
-    vim.api.nvim_set_keymap('n', '<Plug>KommentaryLine', '<cmd>call v:lua.kommentary.go(' .. modes.line .. ')<cr>', { noremap = true, silent = true })
-    vim.api.nvim_set_keymap('v', '<Plug>KommentaryVisual', '<cmd>call v:lua.kommentary.go(' .. modes.visual .. ')<cr>', { noremap = true, silent = true })
-    vim.api.nvim_set_keymap('v', '<Plug>KommentaryVisualSingles', '<cmd>lua require("kommentary");kommentary.go(' .. modes.visual .. ', ' .. "{kommentary.toggle_comment_singles}" .. ')<cr>', { noremap = true, silent = false })
+    --[[ The naming convention for these keymappings is: <Plug>kommentary_mode_suffix
+    where suffix is either default, if it's the default behaviour, or a keyword
+    indicating what is special about this mapping, for example consider the
+    mapping `<Plug>kommentary_visual_singles`, this is a mapping for visual mode
+    which will always use single-line comment style, instead of the default,
+    which would be multi-line comment-style if the range is longer than one line. ]]
+    -- Defaults
+    vim.api.nvim_set_keymap('n', '<Plug>kommentary_motion_default',
+        'v:lua.kommentary.go(' .. modes.init .. ')',
+        { noremap = true, expr = true })
+    vim.api.nvim_set_keymap('n', '<Plug>kommentary_line_default',
+        '<cmd>call v:lua.kommentary.go(' .. modes.line .. ')<cr>',
+        { noremap = true, silent = true })
+    vim.api.nvim_set_keymap('v', '<Plug>kommentary_visual_default',
+        '<cmd>call v:lua.kommentary.go(' .. modes.visual .. ')<cr>',
+        { noremap = true, silent = true })
+    -- Non-default, Motion
+    --[[ Atm, we can't pass a custom callback function to kommentary.go through
+    a motion, from trying it out it seems as if you need to set the operatorfunc
+    to a function, but without (), i.e. `v:lua.kommentary.go` instead of
+    `v:lua.kommentary.go()`, because in the second example the function just
+    wouldn't be called at all. Hopefully I missed something in the documentation. ]]
+    -- Non-default, Line
+    -- Non-default, Visual
+    vim.api.nvim_set_keymap('v', '<Plug>kommentary_visual_singles',
+        '<cmd>lua require("kommentary");kommentary.go(' .. modes.visual .. ', '
+        .. "{kommentary.toggle_comment_singles}" .. ')<cr>',
+        { noremap = true, silent = false })
 end
 
 --[[--

--- a/lua/kommentary/config.lua
+++ b/lua/kommentary/config.lua
@@ -7,6 +7,10 @@ convenience functions for retrieving configuration parameters.
 local util = require("kommentary.util")
 local default = {"//", {"/*", "*/"}}
 local M = {}
+--[[ These are the available modes that can be passed to
+`kommentary.go`, we need to choose the appropriate one for
+each mapping depending on the mode of the mapping ]]
+M.context = util.enum({"line", "visual", "motion", "init"})
 
 --[[--
 Set up keymappings.
@@ -24,9 +28,6 @@ Sets up <Plug>KommentaryLine, which is what you should use for commenting out si
 @treturn nil
 ]]
 function M.setup()
-    --[[ These are the available modes that can be passed to kommentary.go, we
-    need to choose the appropriate one depending on the mode of the mapping ]]
-    local modes = util.enum({"line", "visual", "motion", "init"})
     --[[ The naming convention for these keymappings is: <Plug>kommentary_mode_suffix
     where suffix is either default, if it's the default behaviour, or a keyword
     indicating what is special about this mapping, for example consider the
@@ -35,13 +36,13 @@ function M.setup()
     which would be multi-line comment-style if the range is longer than one line. ]]
     -- Defaults
     vim.api.nvim_set_keymap('n', '<Plug>kommentary_motion_default',
-        'v:lua.kommentary.go(' .. modes.init .. ')',
+        'v:lua.kommentary.go(' .. M.context.init .. ')',
         { noremap = true, expr = true })
     vim.api.nvim_set_keymap('n', '<Plug>kommentary_line_default',
-        '<cmd>call v:lua.kommentary.go(' .. modes.line .. ')<cr>',
+        '<cmd>call v:lua.kommentary.go(' .. M.context.line .. ')<cr>',
         { noremap = true, silent = true })
     vim.api.nvim_set_keymap('v', '<Plug>kommentary_visual_default',
-        '<cmd>call v:lua.kommentary.go(' .. modes.visual .. ')<cr>',
+        '<cmd>call v:lua.kommentary.go(' .. M.context.visual .. ')<cr>',
         { noremap = true, silent = true })
     -- Non-default, Motion
     --[[ Atm, we can't pass a custom callback function to kommentary.go through
@@ -52,7 +53,7 @@ function M.setup()
     -- Non-default, Line
     -- Non-default, Visual
     vim.api.nvim_set_keymap('v', '<Plug>kommentary_visual_singles',
-        '<cmd>lua require("kommentary");kommentary.go(' .. modes.visual .. ', '
+        '<cmd>lua require("kommentary");kommentary.go(' .. M.context.visual .. ', '
         .. "{kommentary.toggle_comment_singles}" .. ')<cr>',
         { noremap = true, silent = false })
 end

--- a/lua/kommentary/init.lua
+++ b/lua/kommentary/init.lua
@@ -5,20 +5,43 @@ This module handles the initialization of the plugin.
 ]]
 local kommentary = require("kommentary.kommentary")
 local config = require("kommentary.config")
+local util = require("kommentary.util")
 local M = {}
+local context = util.enum({"line", "visual", "motion", "init"})
+local modes = config.get_modes()
 
 --[[--
-Toggle comment on current line, selection or motion.
+Function to be called by mappings.
+This acts as a middle-man, when called it will figure out the context of the
+call, so if it was called on a single line, or from a selection/motion, and
+also the range of the operation, so on which line to start and end.
+It will then call another function which takes care of calling the functions
+in kommentary.kommentary, which then actually comments out the range.
+You can overload this function with another function as an argument, which
+will overwrite the function that gets called at the end. The arguments
+passed to the second function are: line_number_start, line_number_end, context
 @tparam string ... Optional string indicating the mode to choose, 'single_line'
 	will operate on the current line, 'visual' will use the current visual
 	selection, otherwise it will assume a motion (Arguments will be
 	automatically passed by operatorfunc).
+@tparam ?string|function ... Optional function to call instead of the normal
+toggle_comment at the end of this function
 @treturn ?string|nil If called without arguments, it sets itself as operatorfunc
 	and returns 'g@' to be used in an expression mapping, otherwise it will
 	comment out and not return anything.
 ]]
-function M.toggle_comment(...)
+function M.go(...)
     local args = {...}
+    -- The 3 possible contexts from which this function can be called
+    local calling_context = args[1]
+    local line_number_start = nil
+    local line_number_end = nil
+    local callback_function = args[2]
+    --[[ If the second argument is not nil, it's a table containing the callback
+    function, extract that function from the table ]]
+    if type(callback_function) == "table" then
+        callback_function = callback_function[1]
+    end
     --[[ When called without any arguments (gc), return g@ (Which will be inserted
     into the mapping literaly, since the mapping is an <expr>, so you have gc
     will enter g@), before that set operatorfunc, which is the function that
@@ -26,28 +49,54 @@ function M.toggle_comment(...)
     typing gc will be as if you typed g@, then you can do a motion like 5j,
     now the operatorfunc gets called and has information about the motion,
     such as the range on which the motion operated. See :h operatorfunc. ]]
-    if #args <= 0 then
-        vim.api.nvim_set_option('operatorfunc', 'v:lua.kommentary.toggle_comment')
+    if calling_context == context.init then
+        vim.api.nvim_set_option('operatorfunc', 'v:lua.kommentary.go')
         return "g@"
     end
-    local modes = config.get_modes()
     --[[ Special argument passed by <Plug>KommentaryLine (gcc) to operate
     on just the current line ]]
-    if args[1] == "single_line" then
-        local row = vim.api.nvim_win_get_cursor(0)[1]
-        kommentary.toggle_comment_line(row, modes.normal)
-    elseif args[1] == "visual" then
-        local line_number_start = vim.fn.getpos('v')[2]
-        local line_number_end = vim.fn.getcurpos()[2]
-        kommentary.toggle_comment_range(line_number_start, line_number_end, modes.normal)
-    else
+    if calling_context == context.line then
+        line_number_start = vim.api.nvim_win_get_cursor(0)[1]
+	line_number_end = line_number_start
+    elseif calling_context == context.visual then
+        --[[ When using g@, the marks < and > will contain the position of the
+        start and the end of the selection, respectively. vim.fn.getpos() returns
+        a tuple with the line and column of the position. ]]
+        line_number_start = vim.fn.getpos('v')[2]
+        line_number_end = vim.fn.getcurpos()[2]
+    elseif args[1] == "line" or
+	    args[1] == "char" or
+	    args[1] == "block" then
         --[[ When using g@, the marks [ and ] will contain the position of the
         start and the end of the motion, respectively. vim.fn.getpos() returns
         a tuple with the line and column of the position. ]]
-        local line_number_start = vim.fn.getpos("'[")[2]
-        local line_number_end = vim.fn.getpos("']")[2]
-        kommentary.toggle_comment_range(line_number_start, line_number_end, modes.normal)
+        line_number_start = vim.fn.getpos("'[")[2]
+        line_number_end = vim.fn.getpos("']")[2]
+        calling_context = context.motion
     end
+    if callback_function == nil then
+	    M.toggle_comment(line_number_start, line_number_end, calling_context)
+    else
+	    callback_function(line_number_start, line_number_end, calling_context)
+    end
+end
+
+function M.toggle_comment(...)
+    local args = {...}
+    local line_number_start, line_number_end = args[1], args[2]
+    local calling_context = args[3]
+    local mode = modes.normal
+    if calling_context == context.line then
+	    mode = modes.force_single
+    end
+    kommentary.toggle_comment_range(line_number_start, line_number_end, mode)
+end
+
+function M.toggle_comment_singles(...)
+    local args = {...}
+    local line_number_start, line_number_end = args[1], args[2]
+    local mode = modes.force_single
+    kommentary.toggle_comment_range(line_number_start, line_number_end, mode)
 end
 
 return M

--- a/lua/kommentary/init.lua
+++ b/lua/kommentary/init.lua
@@ -5,7 +5,6 @@ This module handles the initialization of the plugin.
 ]]
 local kommentary = require("kommentary.kommentary")
 local config = require("kommentary.config")
-local util = require("kommentary.util")
 local M = {}
 local context = config.context
 local modes = config.get_modes()

--- a/lua/kommentary/init.lua
+++ b/lua/kommentary/init.lua
@@ -7,19 +7,25 @@ local kommentary = require("kommentary.kommentary")
 local config = require("kommentary.config")
 local util = require("kommentary.util")
 local M = {}
-local context = util.enum({"line", "visual", "motion", "init"})
+local context = config.context
 local modes = config.get_modes()
 
 --[[--
 Function to be called by mappings.
-This acts as a middle-man, when called it will figure out the context of the
-call, so if it was called on a single line, or from a selection/motion, and
-also the range of the operation, so on which line to start and end.
-It will then call another function which takes care of calling the functions
-in kommentary.kommentary, which then actually comments out the range.
-You can overload this function with another function as an argument, which
-will overwrite the function that gets called at the end. The arguments
-passed to the second function are: line_number_start, line_number_end, context
+This function should be called by all the mappings, it will figure out two things:
+    * The context of the call, meaning if the mapping was triggered in on a
+      single line, or from a selection/motion
+    * The range of the operation, meaning on which line the operation starts and ends.
+This function does not, however, manipulate the buffer in any way, that is left up to
+other functions to allow for greater customizability. At the end of this function, it
+will call a *callback* function with the following arguments:
+    line_number_start, line_number_end, context
+This callback function, by default, will be `kommentary.toggle_comment`, and will
+toggle the range specified. If you wish to use a different function, you can provide
+it in a table as the third argument to this function `kommentary.go`, for example, if
+the desired callback function were called `kommentary.toggle_comment_singles`,
+then you would call this function like this:
+    `kommentary.go(context, {kommentary.toggle_comment_singles})`
 @tparam string ... Optional string indicating the mode to choose, 'single_line'
 	will operate on the current line, 'visual' will use the current visual
 	selection, otherwise it will assume a motion (Arguments will be
@@ -32,38 +38,44 @@ toggle_comment at the end of this function
 ]]
 function M.go(...)
     local args = {...}
-    -- The 3 possible contexts from which this function can be called
+    --[[ The first argument passed to this function represents one of 3 possible
+    contexts in which this function can be called. ]]
     local calling_context = args[1]
     local line_number_start = nil
     local line_number_end = nil
     local callback_function = args[2]
     --[[ If the second argument is not nil, it's a table containing the callback
-    function, extract that function from the table ]]
+    function, extract that function from the table, otherwise leave it as nil ]]
     if type(callback_function) == "table" then
         callback_function = callback_function[1]
     end
-    --[[ When called without any arguments (gc), return g@ (Which will be inserted
-    into the mapping literaly, since the mapping is an <expr>, so you have gc
-    will enter g@), before that set operatorfunc, which is the function that
-    will be called after a motion, when you entered g@ before. So finally,
-    typing gc will be as if you typed g@, then you can do a motion like 5j,
-    now the operatorfunc gets called and has information about the motion,
-    such as the range on which the motion operated. See :h operatorfunc. ]]
+    --[[ When called with the calling context of init (This would be for triggered
+    by gc for example) return g@ (Which has to be inserted into the mapping literaly,
+    meaning the mapping has to be an <expr>) and set the operatorfunc, which is the
+    function that will be called after a motion, provided you entered g@ before.
+    The process will be as follows: typing gc will set the operator func and return g@,
+    since the mapping is an <expr> it's like mapping gc to g@, so g@ will be typed,
+    if you now do a motion like 5j, the operatorfunc gets called with a special,
+    automatically set argument containing information about the nature of the motion.
+    For more information, see :h operatorfunc. ]]
     if calling_context == context.init then
         vim.api.nvim_set_option('operatorfunc', 'v:lua.kommentary.go')
         return "g@"
     end
-    --[[ Special argument passed by <Plug>KommentaryLine (gcc) to operate
-    on just the current line ]]
     if calling_context == context.line then
         line_number_start = vim.api.nvim_win_get_cursor(0)[1]
 	line_number_end = line_number_start
     elseif calling_context == context.visual then
-        --[[ When using g@, the marks < and > will contain the position of the
-        start and the end of the selection, respectively. vim.fn.getpos() returns
-        a tuple with the line and column of the position. ]]
+        --[[ vim.fn.getpos will return the position of something,
+        if you pass 'v' as an argument you will get the start of a
+        visual selection, vim.fn.getcurspos will return the current
+        position of the cursor, so the end of the visual selection. ]]
         line_number_start = vim.fn.getpos('v')[2]
         line_number_end = vim.fn.getcurpos()[2]
+    --[[ When executing a motion after g@, operatorfunc will be
+    called with one of these 3 strings as an argument indicating
+    on what the motion operates, we use it to detect if this function
+    is being called after a motion ]]
     elseif args[1] == "line" or
 	    args[1] == "char" or
 	    args[1] == "block" then

--- a/lua/kommentary/kommentary.lua
+++ b/lua/kommentary/kommentary.lua
@@ -67,37 +67,37 @@ Checks if the specified range in the buffer is a comment.
 ]]
 function M.is_comment(line_number_start, line_number_end)
     line_number_start = line_number_start-1
+    local result = nil
     -- Get the content of the range specififed, this will return a table of lines
     local content = vim.api.nvim_buf_get_lines(0, line_number_start, line_number_end, false)
     -- Check whether the range is a single- or multiline range, get the appropriate comment_string
+    local comment_string = nil
     if #content == 1 then
-        local comment_string = config.get_single(0)
+        comment_string = config.get_single(0)
         if not comment_string == false then
-            return M.is_comment_single(content[1], comment_string)
-        else
+            result = M.is_comment_single(content[1], comment_string)
+        end
+        if not result == true then
             -- In case the language doesn't support single-line comments
             comment_string = config.get_multi(0)
-            return M.is_comment_multi(content, comment_string)
+            result = M.is_comment_multi(content, comment_string)
         end
     elseif #content > 1 then
-        local comment_string = config.get_multi(0)
-        local result = M.is_comment_multi(content, comment_string)
+        comment_string = config.get_multi(0)
+        result = M.is_comment_multi(content, comment_string)
         -- If the language doesn't support multiline comments, or
         -- if the lines are not a multiline comment,
         -- they might still be multiple single-line comments
-        if result then
-            return result
-        else
+        if not result == true then
             comment_string = config.get_single(0)
-            if comment_string == false then
-                return result
-            else
-                return M.is_comment_multi_single(content, comment_string)
+            if not comment_string == false then
+                result = M.is_comment_multi_single(content, comment_string)
             end
         end
     else
         error("Empty range.")
     end
+    return result
 end
 
 --[[--
@@ -191,23 +191,24 @@ normal code, but remove one *level* of commenting instead.
 @treturn nil
 @see comment_out_line
 ]]
-function M.comment_out_range(line_number_start, line_number_end, comment_string)
+function M.comment_out_range(line_number_start, line_number_end, comment_strings)
     line_number_start = line_number_start-1
     local content = vim.api.nvim_buf_get_lines(0, line_number_start, line_number_end, false)
     -- If the range consists of multiple single-line comments
-    local single_comments_array = comment_string == false
-    if not comment_string == false then
-        if M.is_comment_multi(content, comment_string) then
+    local single_comments_array = comment_strings == false
+    if not single_comments_array then
+        if M.is_comment_multi(content, comment_strings) then
             local result = {}
             for i, line in ipairs(content) do
                 local new_line = line
                 if i == 1 then
-                    new_line, _ = string.gsub(new_line, util.escape_pattern(comment_string[1]) .. "%s*", "", 1)
+                    new_line, _ = string.gsub(new_line, util.escape_pattern(comment_strings[1]) .. "%s*", "", 1)
                 end
                 if i == #content then
                     -- This will make sure that only the last occurence of the suffix is replaced
-                    local start_index = util.index_last_occurence(line, comment_string[2])
-                    new_line, _ = util.gsub_from_index(new_line, "%s*" .. util.escape_pattern(comment_string[2]), "", 1, start_index)
+                    local start_index = util.index_last_occurence(new_line, util.escape_pattern(comment_strings[2]))
+                    print(start_index)
+                    new_line, _ = util.gsub_from_index(new_line, "%s*" .. util.escape_pattern(comment_strings[2]), "", 1, start_index-1)
                 end
                 result[i] = new_line
             end
@@ -294,20 +295,19 @@ function M.toggle_comment_range(line_number_start, line_number_end, mode)
     local modes = config.get_modes()
     -- No specfic mode requested, so it can be changed
     if mode == modes.normal then
-        -- If the range is only 1 line long, force the use of single comments
-        if line_number_start == line_number_end then
-            mode = modes.force_single
-        end
-        -- If the language doesn't support multi-line comments
-        if comment_strings == false then
-            mode = modes.force_single
-        end
-        -- If the language doesn't support single-line comments
-        if config.get_single(0) == false then
-            mode = modes.force_multi
-        end
-        -- The order of these checks should gurantee the correct mode is picked
+	    -- If the range is only 1 line long, force the use of single comments
+	    if line_number_start == line_number_end then
+		    mode = modes.force_single
+	    end
     end
+    -- If the language doesn't support multi-line comments
+    if comment_strings == false then
+        mode = modes.force_single
+    -- If the language doesn't support single-line comments
+    elseif config.get_single(0) == false then
+        mode = modes.force_multi
+    end
+    -- The order of these checks should gurantee the correct mode is picked
     if M.is_comment(line_number_start, line_number_end) then
         M.comment_out_range(line_number_start, line_number_end, comment_strings)
     else

--- a/lua/kommentary/kommentary.lua
+++ b/lua/kommentary/kommentary.lua
@@ -207,7 +207,6 @@ function M.comment_out_range(line_number_start, line_number_end, comment_strings
                 if i == #content then
                     -- This will make sure that only the last occurence of the suffix is replaced
                     local start_index = util.index_last_occurence(new_line, util.escape_pattern(comment_strings[2]))
-                    print(start_index)
                     new_line, _ = util.gsub_from_index(new_line, "%s*" .. util.escape_pattern(comment_strings[2]), "", 1, start_index-1)
                 end
                 result[i] = new_line
@@ -307,7 +306,7 @@ function M.toggle_comment_range(line_number_start, line_number_end, mode)
     elseif config.get_single(0) == false then
         mode = modes.force_multi
     end
-    -- The order of these checks should gurantee the correct mode is picked
+    -- The order of the checks above should gurantee the correct mode is picked
     if M.is_comment(line_number_start, line_number_end) then
         M.comment_out_range(line_number_start, line_number_end, comment_strings)
     else

--- a/lua/test/test_util.lua
+++ b/lua/test/test_util.lua
@@ -45,6 +45,7 @@ end
 function Test_Util.test_index_last_occurence()
     lu.assertEquals(util.index_last_occurence('test test test test', 'test'), 16)
     lu.assertEquals(util.index_last_occurence('/* This is what this */ function would be used for */', '*/'), 52)
+    lu.assertEquals(util.index_last_occurence('<!--- This is what this --> function would be used for -->', util.escape_pattern('-->')), 52)
     lu.assertEquals(util.index_last_occurence('', 'test'), 0)
     lu.assertEquals(util.index_last_occurence('test', ''), 5)
 end

--- a/plugin/kommentary.vim
+++ b/plugin/kommentary.vim
@@ -1,6 +1,21 @@
 lua kommentary = require("kommentary")
 lua config = require("kommentary.config")
 lua config.setup()
-nmap gc     <Plug>Kommentary
-vmap gc     <Plug>KommentaryVisualSingles
-nmap gcc     <Plug>KommentaryLine
+
+" The default mapping for line-wise operation; will toggle the range from
+" commented to not-commented and vice-versa, will use a single-line comment.
+nmap gcc     <Plug>kommentary_line_default
+" The default mapping for visual selections; will toggle the range from
+" commented to not-commented and vice-versa, will use multi-line comments when
+" the range is longer than 1 line, otherwise it will use a single-line comment.
+vmap gc     <Plug>kommentary_visual_default
+" The default mapping for motions; will toggle the range from commented to
+" not-commented and vice-versa, will use multi-line comments when the range
+" is longer than 1 line, otherwise it will use a single-line comment.
+nmap gc     <Plug>kommentary_motion_default
+
+" Custom mapping for visual selections; will toggle the range from commented to
+" not-commented and vice-versa, will enforce the use of single-line comments,
+" regardless of the length of the range.
+" vmap gc     <Plug>kommentary_visual_singles
+

--- a/plugin/kommentary.vim
+++ b/plugin/kommentary.vim
@@ -2,5 +2,5 @@ lua kommentary = require("kommentary")
 lua config = require("kommentary.config")
 lua config.setup()
 nmap gc     <Plug>Kommentary
-vmap gc     <Plug>KommentaryVisual
+vmap gc     <Plug>KommentaryVisualSingles
 nmap gcc     <Plug>KommentaryLine


### PR DESCRIPTION
This implements the function `kommentary.go()`, which is what mappings should call from now on. The function will figure out from which context it was called. This context could be:

* `line` for single-line operations, passed by `gcc`
* `visual` for range operations from visual mode, called by `gc`
* `motion` for range operations from motions, called by `g@`
* `init` for settings `operatorfunc` to `kommentary.go`, called by `gc` before a motion

After it figured out the context, it will call the callback function, which is `kommentary.toggle_comment()` by default, this default can be overwriten by the optional second argument to the `kommentary.go()` function.
The callback function will be called with 3 arguments:

1. The index of the line of the start of the operation
2. The index of the line of the end of the operation (Will be the same as the first argument when operating on single lines)
3. The calling context, i.e. the context the function has just figured out

This allows for much easier customization.

An example callback function is also implemented with this PR, `kommentary.toggle_comment_singles()`, which will turn a range into multiple single-line comments.

See also #3.