### PR TITLE
Implement use_consistent_indentation and ignore_whitespace options, refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ require('kommentary.config').configure_language("rust", {
 EOF
 ```
 
+You can also set global defaults, these will be used for all languages, unless you overwrite it for that specific language like shown above:
+```lua
+lua << EOF
+require('kommentary.config').configure_language("default", {
+    prefer_single_line_comments = true,
+})
+EOF
+```
+
 If you set both of the to true, it will use the default.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ require('kommentary.config').configure_language("rust", {
 EOF
 ```
 
+If you set both of the to true, it will use the default.
+
 You can also set global defaults, these will be used for all languages, unless you overwrite it for that specific language like shown above:
 ```lua
 lua << EOF
@@ -79,7 +81,6 @@ require('kommentary.config').configure_language("default", {
 EOF
 ```
 
-If you set both of the to true, it will use the default.
 
 ## Contributing
 

--- a/lua/kommentary/config.lua
+++ b/lua/kommentary/config.lua
@@ -208,7 +208,7 @@ end
 
 --[[--
 Generate a config table from a commentstring.
-@tparam string commenting The commentstring to convert, see :h commentstring
+@tparam string commentstring The commentstring to convert, see :h commentstring
 @treturn {?bool|string,?bool{string,string}} Config table for commentstring
 ]]
 function M.config_from_commentstring(commentstring)

--- a/lua/kommentary/kommentary.lua
+++ b/lua/kommentary/kommentary.lua
@@ -15,8 +15,9 @@ Check if a string is a single-line comment.
 @tparam string comment_string The prefix of a single-line comment
 @treturn bool true if it is a single-line comment, otherwise false
 ]]
-function M.is_comment_single(line, comment_string)
+function M.is_comment_single(line, configuration)
     -- Since the line might be indented, trim all whitespace
+    local comment_string = configuration[1]
     line = util.trim(line)
     return line:sub(1, #comment_string) == comment_string
 end
@@ -28,7 +29,8 @@ Check if a string is a multi-line comment.
         suffix of a multi-line comment
 @treturn bool true if it is a multi-line comment, otherwise false
 ]]
-function M.is_comment_multi(lines, comment_strings)
+function M.is_comment_multi(lines, configuration)
+    local comment_strings = configuration[2]
     if comment_strings == false or #lines < 1 then
         return false
     end
@@ -46,12 +48,13 @@ Check if a string is a range of single-line comments.
 @tparam string comment_string The prefix of a single-line comment
 @treturn bool true if it is a range of single-line comments
 ]]
-function M.is_comment_multi_single(lines, comment_string)
+function M.is_comment_multi_single(lines, configuration)
+    local comment_string = configuration[1]
     if comment_string == false or #lines < 1 then
         return false
     end
     for _, line in ipairs(lines) do
-        if not M.is_comment_single(line, comment_string) then
+        if not M.is_comment_single(line, configuration) then
             return false
         end
     end
@@ -65,7 +68,7 @@ Checks if the specified range in the buffer is a comment.
 @tparam int line_number_end End of the range, inclusive
 @treturn bool true if it is a multi-line comment, otherwise false
 ]]
-function M.is_comment(line_number_start, line_number_end)
+function M.is_comment(line_number_start, line_number_end, configuration)
     line_number_start = line_number_start-1
     local result = nil
     -- Get the content of the range specififed, this will return a table of lines
@@ -73,25 +76,25 @@ function M.is_comment(line_number_start, line_number_end)
     -- Check whether the range is a single- or multiline range, get the appropriate comment_string
     local comment_string = nil
     if #content == 1 then
-        comment_string = config.get_single(0)
+        comment_string = configuration[1]
         if not comment_string == false then
-            result = M.is_comment_single(content[1], comment_string)
+            result = M.is_comment_single(content[1], configuration)
         end
         if not result == true then
             -- In case the language doesn't support single-line comments
-            comment_string = config.get_multi(0)
-            result = M.is_comment_multi(content, comment_string)
+            comment_string = configuration[2]
+            result = M.is_comment_multi(content, configuration)
         end
     elseif #content > 1 then
-        comment_string = config.get_multi(0)
-        result = M.is_comment_multi(content, comment_string)
+        comment_string = configuration[2]
+        result = M.is_comment_multi(content, configuration)
         -- If the language doesn't support multiline comments, or
         -- if the lines are not a multiline comment,
         -- they might still be multiple single-line comments
         if not result == true then
-            comment_string = config.get_single(0)
+            comment_string = configuration[1]
             if not comment_string == false then
-                result = M.is_comment_multi_single(content, comment_string)
+                result = M.is_comment_multi_single(content, configuration)
             end
         end
     else
@@ -106,7 +109,8 @@ Turns the line into a single-line comment.
 @tparam string comment_string The prefix of a single-line comment
 @treturn nil
 ]]
-function M.comment_in_line(line_number, comment_string)
+function M.comment_in_line(line_number, configuration)
+    local comment_string = configuration[1]
     local content = vim.api.nvim_buf_get_lines(0, line_number-1, line_number, false)[1]
     vim.api.nvim_buf_set_lines(0, line_number-1, line_number, false, {util.insert_at_beginning(content, comment_string .. " ")})
 end
@@ -121,9 +125,10 @@ turn into:  `-- This has been commented out 2 times`.
 @tparam string comment_string The prefix of a single-line comment
 @treturn nil
 ]]
-function M.comment_out_line(line_number, comment_string)
+function M.comment_out_line(line_number, configuration)
+    local comment_string = configuration[1]
     local content = vim.api.nvim_buf_get_lines(0, line_number-1, line_number, false)[1]
-    if M.is_comment_single(content, comment_string) then
+    if M.is_comment_single(content, configuration) then
         local result, _ = string.gsub(content, util.escape_pattern(comment_string) .. "%s*", "", 1)
         vim.api.nvim_buf_set_lines(0, line_number-1, line_number, false, {result})
     end
@@ -136,12 +141,31 @@ Turns the range into multiple single-line comments.
 @tparam string comment_string The prefix of a single-line comment
 @treturn nil
 ]]
-function M.comment_in_range_single(line_number_start, line_number_end, comment_string)
+function M.comment_in_range_single(line_number_start, line_number_end, configuration)
     line_number_start = line_number_start-1
+    local comment_string = configuration[1]
     local content = vim.api.nvim_buf_get_lines(0, line_number_start, line_number_end, false)
+    --[[ If this is set to nil, for each line the comment will be inserted before
+    the first non-whitespace character, otherwise all comments will be
+    inserted at this index. ]]
     local result = {}
-    for _, line in ipairs(content) do
-        table.insert(result, util.insert_at_beginning(line, comment_string .. " "))
+    -- This is the flag for using consistend indentation
+    if configuration[5] == true then
+        local comment_index = #content[1]
+        -- Search for the lowest level of indentation
+        for _, line in ipairs(content) do
+            local index = string.find(line, "%S")
+            if index < comment_index then
+                comment_index = index
+            end
+        end
+        for _, line in ipairs(content) do
+            table.insert(result, util.insert_at_index(line, comment_string .. " ", comment_index))
+        end
+    else
+        for _, line in ipairs(content) do
+            table.insert(result, util.insert_at_beginning(line, comment_string .. " "))
+        end
     end
     vim.api.nvim_buf_set_lines(0, line_number_start, line_number_end, false, result)
 end
@@ -156,29 +180,33 @@ into multiple single-line comments instead.
         suffix of a multi-line comment
 @treturn nil
 ]]
-function M.comment_in_range(line_number_start, line_number_end, comment_string)
+function M.comment_in_range(line_number_start, line_number_end, configuration)
     line_number_start = line_number_start-1
-    local content = vim.api.nvim_buf_get_lines(0, line_number_start, line_number_end, false)
-    if comment_string == false then
-        -- The language doesn't support multi-line comments, just loop over
-        -- each line and comment it in with a single-line comment
-        M.comment_in_range_single(line_number_start, line_number_end)
+    local comment_strings = configuration[2]
+    local content = vim.api.nvim_buf_get_lines(0, line_number_start,
+        line_number_end, false)
+    if comment_strings == false then
+        -- The language doesn't support multi-line comments
+        M.comment_in_range_single(line_number_start, line_number_end, configuration)
     else
         local result = {}
         if line_number_start == line_number_end then
-            result = {util.insert_at_beginning(content, comment_string[1] .. " ") .. " " .. comment_string[2]}
+            result = {util.insert_at_beginning(content, comment_strings[1] .. " ")
+                .. " " .. comment_strings[2]}
         else
             result = {}
             for i, line in ipairs(content) do
                 if i == 1 then
-                    result[i] = util.insert_at_beginning(line, comment_string[1] .. " ")
+                    result[i] = util.insert_at_beginning(line,
+                        comment_strings[1] .. " ")
                 else
                     result[i] = line
                 end
             end
-            result[#result] = result[#result] .. " " .. comment_string[2]
+            result[#result] = result[#result] .. " " .. comment_strings[2]
         end
-        vim.api.nvim_buf_set_lines(0, line_number_start, line_number_end, false, result)
+        vim.api.nvim_buf_set_lines(0, line_number_start, line_number_end, false,
+            result)
     end
 end
 
@@ -189,12 +217,13 @@ Turns the range, multiple single-line comments, into normal code.
 @tparam string comment_string The prefix of a single-line comment
 @treturn nil
 ]]
-function M.comment_out_range_single(line_number_start, line_number_end, comment_string)
+function M.comment_out_range_single(line_number_start, line_number_end, configuration)
     line_number_start = line_number_start-1
+    local comment_string = configuration[1]
     local content = vim.api.nvim_buf_get_lines(0, line_number_start, line_number_end, false)
     local result = {}
     for _, line in ipairs(content) do
-        local new_line, _ = string.gsub(line, util.escape_pattern(comment_string) .. "%s*", "", 1)
+        local new_line, _ = string.gsub(line, util.escape_pattern(comment_string) .. "%s?", "", 1)
         table.insert(result, new_line)
     end
     vim.api.nvim_buf_set_lines(0, line_number_start, line_number_end, false, result)
@@ -213,13 +242,14 @@ normal code, but remove one *level* of commenting instead.
 @treturn nil
 @see comment_out_line
 ]]
-function M.comment_out_range(line_number_start, line_number_end, comment_strings)
+function M.comment_out_range(line_number_start, line_number_end, configuration)
     line_number_start = line_number_start-1
+    local comment_strings = configuration[2]
     local content = vim.api.nvim_buf_get_lines(0, line_number_start, line_number_end, false)
     -- If the range consists of multiple single-line comments
     local single_comments_array = comment_strings == false
     if not single_comments_array then
-        if M.is_comment_multi(content, comment_strings) then
+        if M.is_comment_multi(content, configuration) then
             local result = {}
             for i, line in ipairs(content) do
                 local new_line = line
@@ -243,7 +273,7 @@ function M.comment_out_range(line_number_start, line_number_end, comment_strings
         range just doesn't use them. Because comment_out_range_single
         also subracts one from the line_number_start, we have to add it
         back here as to not end up with a subraction of 2 ]]
-        M.comment_out_range_single(line_number_start+1, line_number_end, config.get_single(0))
+        M.comment_out_range_single(line_number_start+1, line_number_end, configuration)
     end
 end
 
@@ -266,7 +296,8 @@ comments before starting to toggle comments, so for example in lua:
 @treturn nil
 ]]
 function M.toggle_comment_line(line_number, mode)
-    local comment_string = config.get_single(0)
+    local configuration = config.get_config(0)
+    local comment_string = configuration[1]
     local modes = config.get_modes()
     -- No specfic mode requested, so it can be changed
     if mode == modes.normal then
@@ -275,11 +306,11 @@ function M.toggle_comment_line(line_number, mode)
             mode = modes.force_multi
         end
     end
-    if M.is_comment(line_number, line_number) then
+    if M.is_comment(line_number, line_number, configuration) then
         if mode == modes.force_multi then
-            M.comment_out_range(line_number, line_number, config.get_multi(0))
+            M.comment_out_range(line_number, line_number, configuration)
         else
-            M.comment_out_line(line_number, comment_string)
+            M.comment_out_line(line_number, configuration)
         end
     else
         if mode == modes.force_multi then
@@ -311,16 +342,16 @@ function M.toggle_comment_range(line_number_start, line_number_end, mode)
     if line_number_end < line_number_start then
         line_number_start, line_number_end = line_number_end, line_number_start
     end
-    local comment_strings = config.get_multi(0)
+    local configuration = config.get_config(0)
     local modes = config.get_modes()
     mode = config.get_mode(line_number_start, line_number_end, mode)
-    if M.is_comment(line_number_start, line_number_end) then
-        M.comment_out_range(line_number_start, line_number_end, comment_strings)
+    if M.is_comment(line_number_start, line_number_end, configuration) then
+        M.comment_out_range(line_number_start, line_number_end, configuration)
     else
         if mode == modes.force_single then
-            M.comment_in_range_single(line_number_start, line_number_end, config.get_single(0))
+            M.comment_in_range_single(line_number_start, line_number_end, configuration)
         else
-            M.comment_in_range(line_number_start, line_number_end, comment_strings)
+            M.comment_in_range(line_number_start, line_number_end, configuration)
         end
     end
 end

--- a/lua/kommentary/kommentary.lua
+++ b/lua/kommentary/kommentary.lua
@@ -12,7 +12,7 @@ local M = {}
 --[[--
 Check if a string is a single-line comment.
 @tparam string line A single line string
-@tparam string comment_string The prefix of a single-line comment
+@tparam table configuration The entire config table currently in use
 @treturn bool true if it is a single-line comment, otherwise false
 ]]
 function M.is_comment_single(line, configuration)
@@ -45,7 +45,7 @@ end
 --[[--
 Check if a string is a range of single-line comments.
 @tparam {string,...} lines A table of lines
-@tparam string comment_string The prefix of a single-line comment
+@tparam table configuration The entire config table currently in use
 @treturn bool true if it is a range of single-line comments
 ]]
 function M.is_comment_multi_single(lines, configuration)
@@ -68,6 +68,7 @@ end
 Checks if the specified range in the buffer is a comment.
 @tparam int line_number_start Start of the range, inclusive
 @tparam int line_number_end End of the range, inclusive
+@tparam table configuration The entire config table currently in use
 @treturn bool true if it is a multi-line comment, otherwise false
 ]]
 function M.is_comment(line_number_start, line_number_end, configuration)
@@ -108,7 +109,7 @@ end
 --[[--
 Turns the line into a single-line comment.
 @tparam int line_number Line to operate on
-@tparam string comment_string The prefix of a single-line comment
+@tparam table configuration The entire config table currently in use
 @treturn nil
 ]]
 function M.comment_in_line(line_number, configuration)
@@ -124,7 +125,7 @@ multiple times, for example in lua: `-- -- This has been commented out 2 times`,
 in which case it will remove one *level* of comments, so in this example it will
 turn into:  `-- This has been commented out 2 times`.
 @tparam int line_number Line to operate on
-@tparam string comment_string The prefix of a single-line comment
+@tparam table configuration The entire config table currently in use
 @treturn nil
 ]]
 function M.comment_out_line(line_number, configuration)
@@ -140,7 +141,7 @@ end
 Turns the range into multiple single-line comments.
 @tparam int line_number_start Start of the range, inclusive
 @tparam int line_number_end End of the range, inclusive
-@tparam string comment_string The prefix of a single-line comment
+@tparam table configuration The entire config table currently in use
 @treturn nil
 ]]
 function M.comment_in_range_single(line_number_start, line_number_end, configuration)
@@ -149,12 +150,12 @@ function M.comment_in_range_single(line_number_start, line_number_end, configura
     local content = vim.api.nvim_buf_get_lines(0, line_number_start, line_number_end, false)
     --[[ This function will return the index at which to insert the comment prefix.
     in the current state, this function will return the index of the first
-    non-whitespace character, if the option for consistend indentation is set,
+    non-whitespace character, if the option for consistent indentation is set,
     it will later be overwritten to return a constant number (the lowest
     index at which to insert indentation) ]]
     local comment_index = function(line) return string.find(line, "%S") end
     local result = {}
-    -- This is the flag for using consistend indentation
+    -- This is the flag for using consistent indentation
     if configuration[5] == true then
         --[[ This is the variable for keeping track of the lowest index we find,
         initially we set it to -1, then loop over all lines until we find one
@@ -237,7 +238,7 @@ end
 Turns the range, multiple single-line comments, into normal code.
 @tparam int line_number_start Start of the range, inclusive
 @tparam int line_number_end End of the range, inclusive
-@tparam string comment_string The prefix of a single-line comment
+@tparam table configuration The entire config table currently in use
 @treturn nil
 ]]
 function M.comment_out_range_single(line_number_start, line_number_end, configuration)

--- a/lua/kommentary/kommentary.lua
+++ b/lua/kommentary/kommentary.lua
@@ -25,8 +25,7 @@ end
 --[[--
 Check if a string is a multi-line comment.
 @tparam {string,...} lines A table of lines
-@tparam {string,string} comment_strings A tuple containing the prefix and
-        suffix of a multi-line comment
+@tparam table configuration The entire config table currently in use
 @treturn bool true if it is a multi-line comment, otherwise false
 ]]
 function M.is_comment_multi(lines, configuration)
@@ -200,8 +199,7 @@ If the language doesn't support multi-line comments, it will turn the range
 into multiple single-line comments instead.
 @tparam int line_number_start Start of the range, inclusive
 @tparam int line_number_end End of the range, inclusive
-@tparam {string,string} comment_string A tuple containing the prefix and
-        suffix of a multi-line comment
+@tparam table configuration The entire config table currently in use
 @treturn nil
 ]]
 function M.comment_in_range(line_number_start, line_number_end, configuration)
@@ -261,8 +259,7 @@ Just as with commenting out a single line, this might not make the range into
 normal code, but remove one *level* of commenting instead.
 @tparam int line_number_start Start of the range, inclusive
 @tparam int line_number_end End of the range, inclusive
-@tparam {string,string} comment_string A tuple containing the prefix and
-        suffix of a multi-line comment
+@tparam table configuration The entire config table currently in use
 @treturn nil
 @see comment_out_line
 ]]

--- a/lua/kommentary/util.lua
+++ b/lua/kommentary/util.lua
@@ -16,6 +16,15 @@ function M.trim(s)
 end
 
 --[[--
+Returns true if the given string is only whitespace.
+@tparam string s String to check
+@treturn bool True if the string consists of only whitespace
+]]
+function M.is_empty(s)
+    return string.match(s, "%S") == nil
+end
+
+--[[--
 Insert prefix before the first non-whitespace character in string.
 @tparam string line String to which the prefix will be prepended
 @tparam string prefix Prefix put at the beginning of the string

--- a/lua/kommentary/util.lua
+++ b/lua/kommentary/util.lua
@@ -51,7 +51,7 @@ Insert prefix at index.
 ]]
 function M.insert_at_index(line, prefix, index)
     -- If the line is empty, just return the prefix with any whitespace stipped
-    if line == nil or line == '' then
+    if M.is_empty(line) then
         return M.trim(prefix)
     end
     --[[ If there are no non-whitespace characters on the line,

--- a/lua/kommentary/util.lua
+++ b/lua/kommentary/util.lua
@@ -47,7 +47,7 @@ Insert prefix at index.
 @tparam string line String to which the prefix will be prepended
 @tparam string prefix Prefix that will be inserted at index
 @tparam int index Where to insert the prefix
-@treturn string String with prefix before first non-whitespace character
+@treturn string String with prefix at index
 ]]
 function M.insert_at_index(line, prefix, index)
     -- If the line is empty, just return the prefix with any whitespace stipped

--- a/lua/kommentary/util.lua
+++ b/lua/kommentary/util.lua
@@ -54,9 +54,9 @@ function M.insert_at_index(line, prefix, index)
     if M.is_empty(line) then
         return M.trim(prefix)
     end
-    --[[ If there are no non-whitespace characters on the line,
-    use 1 as a starting index ]]
+    --[[ If the index is lower than 1 or nil, set it to 1 ]]
     index = index == nil and 1 or index
+    index = index < 0 and 1 or index
     return string.sub(line, 0, index-1) .. prefix .. string.sub(line, index, #line)
 end
 

--- a/lua/kommentary/util.lua
+++ b/lua/kommentary/util.lua
@@ -34,6 +34,24 @@ function M.insert_at_beginning(line, prefix)
 end
 
 --[[--
+Insert prefix at index.
+@tparam string line String to which the prefix will be prepended
+@tparam string prefix Prefix that will be inserted at index
+@tparam int index Where to insert the prefix
+@treturn string String with prefix before first non-whitespace character
+]]
+function M.insert_at_index(line, prefix, index)
+    -- If the line is empty, just return the prefix with any whitespace stipped
+    if line == nil or line == '' then
+        return M.trim(prefix)
+    end
+    --[[ If there are no non-whitespace characters on the line,
+    use 1 as a starting index ]]
+    index = index == nil and 1 or index
+    return string.sub(line, 0, index-1) .. prefix .. string.sub(line, index, #line)
+end
+
+--[[--
 Get the index of the last occurence of a pattern in a string.
 @tparam string str String to search for the pattern
 @tparam string pattern Pattern to search for

--- a/lua/test/test_util.lua
+++ b/lua/test/test_util.lua
@@ -42,6 +42,11 @@ function Test_Util.test_insert_at_beginning()
     lu.assertEquals(util.insert_at_beginning('    ', '// '), '//     ')
 end
 
+function Test_Util.test_insert_at_index()
+    lu.assertEquals(util.insert_at_index('test', '// ', 1), '// test')
+    lu.assertEquals(util.insert_at_index('test', '// ', 3), 'te// st')
+end
+
 function Test_Util.test_index_last_occurence()
     lu.assertEquals(util.index_last_occurence('test test test test', 'test'), 16)
     lu.assertEquals(util.index_last_occurence('/* This is what this */ function would be used for */', '*/'), 52)

--- a/lua/test/test_util.lua
+++ b/lua/test/test_util.lua
@@ -29,6 +29,13 @@ function Test_Util.test_trim_spaces_and_tabs()
     lu.assertEquals(util.trim(''), '')
 end
 
+function Test_Util.test_is_empty()
+    lu.assertEquals(util.is_empty('  test'), false)
+    lu.assertEquals(util.is_empty('  '), true)
+    lu.assertEquals(util.is_empty('	'), true)
+    lu.assertEquals(util.is_empty('	  '), true)
+end
+
 function Test_Util.test_insert_at_beginning()
     lu.assertEquals(util.insert_at_beginning('test', '// '), '// test')
     lu.assertEquals(util.insert_at_beginning('test', '//'), '//test')

--- a/lua/test/test_util.lua
+++ b/lua/test/test_util.lua
@@ -52,6 +52,7 @@ end
 function Test_Util.test_insert_at_index()
     lu.assertEquals(util.insert_at_index('test', '// ', 1), '// test')
     lu.assertEquals(util.insert_at_index('test', '// ', 3), 'te// st')
+    lu.assertEquals(util.insert_at_index('', '// ', 1), 't// ')
 end
 
 function Test_Util.test_index_last_occurence()

--- a/plugin/kommentary.vim
+++ b/plugin/kommentary.vim
@@ -23,8 +23,3 @@ nmap gc     <Plug>kommentary_motion_default
 " regardless of the length of the range.
 " vmap gc     <Plug>kommentary_visual_singles
 
-lua << EOF
-require('kommentary.config').configure_language("default", {
-    prefer_single_line_comments = true,
-})
-EOF

--- a/plugin/kommentary.vim
+++ b/plugin/kommentary.vim
@@ -22,3 +22,9 @@ nmap gc     <Plug>kommentary_motion_default
 " not-commented and vice-versa, will enforce the use of single-line comments,
 " regardless of the length of the range.
 " vmap gc     <Plug>kommentary_visual_singles
+
+lua << EOF
+require('kommentary.config').configure_language("default", {
+    prefer_single_line_comments = true,
+})
+EOF


### PR DESCRIPTION
This implements a global config system, as well as the implements use_consistent_indentation (See #5) and ignore_whitespace (See #10) options.

It also refactors the code in `kommentary.lua` so that now the entire configuration gets passed around, not just the current comment_string, this should make adding any potential new config options much less painful.