### PR TITLE
Fixing exceptions for filetypes that do not exist

### DIFF
--- a/lua/kommentary/config.lua
+++ b/lua/kommentary/config.lua
@@ -286,6 +286,7 @@ function M.get_config(filetype)
         result = {unpack(M.config[filetype])}
     end
     -- Fill in missing or "default" fields
+    if result == nil then return end
     for i = 1,6,1 do
         if result[i] == "default" or result[i] == nil then
             result[i] = M.get_default_config()[i]
@@ -310,6 +311,7 @@ function M.get_default_mode(filetype)
     local modes = M.get_modes()
     --[[ If both prefer_multi and prefer_single are set, or if none of them are
     set, use the default mode. ]]
+    if config == nil then return end
     if (config[3] and config[4]) or (not config[3] and not config[4]) then
         return modes.normal
     end
@@ -338,6 +340,7 @@ If the language doesn't support single line comments,
 function M.get_mode(line_number_start, line_number_end, mode)
     local modes = M.get_modes()
     local config = M.get_config(0)
+    if config == nil or modes == nil then return end
     --[[ The function was called with something non-default,
     this overwrites everything else. ]]
     if mode ~= modes.normal then

--- a/lua/kommentary/kommentary.lua
+++ b/lua/kommentary/kommentary.lua
@@ -77,6 +77,7 @@ function M.is_comment(line_number_start, line_number_end, configuration)
     local content = vim.api.nvim_buf_get_lines(0, line_number_start, line_number_end, false)
     -- Check whether the range is a single- or multiline range, get the appropriate comment_string
     local comment_string = nil
+    if configuration == nil then return end
     if #content == 1 then
         comment_string = configuration[1]
         if not comment_string == false then
@@ -204,6 +205,7 @@ into multiple single-line comments instead.
 ]]
 function M.comment_in_range(line_number_start, line_number_end, configuration)
     line_number_start = line_number_start-1
+    if configuration == nil then return end
     local comment_strings = configuration[2]
     local content = vim.api.nvim_buf_get_lines(0, line_number_start,
         line_number_end, false)


### PR DESCRIPTION
Currently when we try and use kommentary for a filetype that does not exist we get a nil error

This can be reproduced by typing in `nvim test.json` and attempting to use kommentary within that file

For now this is an interim patch to catch exceptions during setup to prevent errors. We can further add a message to suggest 'language not supported' in case that it is not.