### PR TITLE
Allow using multiline comments per line for multiline comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,34 @@ require('kommentary.config').configure_language("default", {
 EOF
 ```
 
+Additionally, you can use multi-line comment style for single-line comments. For example, CSS does not have a single-line comment style. For these cases, single-line comments can be configured as a table:
+
+```lua
+lua << EOF
+require('kommentary.config').configure_language("css", {
+    -- This also works if your commentstring is set to "/* %s */"
+    single_line_comment_string = {"/*", "*/"},
+    prefer_single_line_comments = true,
+})
+EOF
+```
+
+With the above configuration, commenting multiple lines of CSS looks like so:
+
+```css
+/* .test { */
+/*   color: red; */
+/* } */
+```
+
+Instead of like so:
+
+```css
+/* .test {
+  color: red;
+} */
+```
+
 ### More configuration options
 
 The `configure_language` provides access to two other options, `use_consistent_indentation` and `ignore_whitespace`. Both are set to true by default, but of course you can overwrite that. 

--- a/lua/kommentary/config.lua
+++ b/lua/kommentary/config.lua
@@ -259,8 +259,13 @@ function M.config_from_commentstring(commentstring)
     if index_placeholder + #placeholder == #commentstring then
         return {vim.trim(commentstring:sub(1, -#placeholder-1)), false}
     end
-    return {false, {vim.trim(commentstring:sub(1, index_placeholder)),
-        vim.trim(commentstring:sub(index_placeholder + #placeholder + 1, -1))}}
+
+    local comment_string = {
+        vim.trim(commentstring:sub(1, index_placeholder)),
+        vim.trim(commentstring:sub(index_placeholder + #placeholder + 1, -1))
+    }
+
+    return {comment_string, comment_string}
 end
 
 --[[--


### PR DESCRIPTION
Hey!

In some languages, only multiline comment style is supported (e.g., CSS supports `/* %s */` style comments). I prefer to use multiline comments to wrap each line when commenting multiple lines. Previously, if I commented multiple lines (using a motion or visual mode), then the result would be like this:

```css
/* .test {
  color: red;
} */
```

I would prefer a result like this:

```css
/* .test { */
/*   color: red; */
/* } */
```

To solve this, I added the possibility to set a table for `single_line_comment_string`, exactly like `multi_line_comment_strings`:

```lua
require('kommentary.config').configure_language("css", {
    single_line_comment_string = {"/*", "*/"},
    prefer_single_line_comments = true,
})
```

Additionally, if the `commentstring` is multi-line (e.g., `/* %s */`), then that sets the option to `{"/*", "*/"}`.

---

What do you think about this feature?

**Note:** The tests seem to be failing for me, so I didn't update them at the moment. Should they be passing? Here's the output when running `lua5.1 test/test_util.lua`:

```
..E.E.
Tests with errors:
------------------
1) Test_Util.test_index_last_occurence
test/test_util.lua:35: attempt to call field 'escape_pattern' (a nil value)
stack traceback:
	test/test_util.lua:35: in function 'Test_Util.test_index_last_occurence'

2) Test_Util.test_insert_at_index
./kommentary/util.lua:46: attempt to index global 'vim' (a nil value)
stack traceback:
	./kommentary/util.lua:46: in function 'insert_at_index'
	test/test_util.lua:29: in function 'Test_Util.test_insert_at_index'

Ran 6 tests in 0.001 seconds, 4 successes, 2 errors
```