### PR TITLE
Unit tests for comment_*_content

### DIFF
--- a/lua/test/kommentary_spec.lua
+++ b/lua/test/kommentary_spec.lua
@@ -1,0 +1,77 @@
+local kommentary = require("kommentary.kommentary")
+local test_cases = require("test.test_cases")
+
+local function parse_friendly_string(s)
+  local lines = string.gmatch(s, "[^\r\n]+")
+  local matches = {}
+
+  for line in lines do
+    local match = string.match(line, "\n?%s*| ?([^\n]*)")
+    table.insert(matches, match)
+  end
+
+  return matches
+end
+
+local function run_test_cases(
+  cases, forward, backward, forward_name, backward_name
+)
+  for i, case in ipairs(cases) do
+    local input = parse_friendly_string(case.input)
+    local expected = parse_friendly_string(case.output)
+    local actual = forward(input, case.config)
+
+    if case.enabled ~= nil and case.enabled == false then
+      return
+    end
+
+    local test_name = string.format("%s (#%d)", forward_name, i)
+    it(test_name, function ()
+      assert.are.same(expected, actual)
+    end)
+
+    if backward ~= nil then
+      local reconstructed = backward(actual, case.config)
+      local test_name = string.format("%s (#%d)", backward_name, i)
+      it(test_name, function ()
+        assert.are.same(input, reconstructed)
+      end)
+    end
+  end
+end
+
+describe("comment", function ()
+
+  run_test_cases(
+    test_cases.comment_in_range_single_content,
+    kommentary.comment_in_range_single_content,
+    kommentary.comment_out_range_single_content,
+    "in range single",
+    "in then out range single"
+  )
+
+  run_test_cases(
+    test_cases.comment_out_range_single_content,
+    kommentary.comment_out_range_single_content,
+    nil,
+    "out range single",
+    nil
+  )
+
+  run_test_cases(
+    test_cases.comment_in_range_content,
+    kommentary.comment_in_range_content,
+    kommentary.comment_out_range_content,
+    "in range",
+    "in then out range"
+  )
+
+  run_test_cases(
+    test_cases.comment_out_range_content,
+    kommentary.comment_out_range_content,
+    nil,
+    "out range",
+    nil
+  )
+
+end)

--- a/lua/test/test_cases.lua
+++ b/lua/test/test_cases.lua
@@ -1,0 +1,175 @@
+local M = {}
+
+M.comment_in_range_single_content = {
+  {
+    config = { "#", nil, nil, nil, true, false },
+    input = [[
+      | import antigravity
+      |
+      | def hello():
+      |     print('hello')
+      |
+      |     print('world')
+    ]],
+    output = [[
+      | # import antigravity
+      | #
+      | # def hello():
+      | #     print('hello')
+      | #
+      | #     print('world')
+    ]],
+  },
+  {
+    config = { "#", nil, nil, nil, true, false },
+    input = [[
+      |     for i in range(42):
+      |         x = i * i
+      |
+      |         # print(x)
+    ]],
+    output = [[
+      |     # for i in range(42):
+      |     #     x = i * i
+      |     #
+      |     #     # print(x)
+    ]],
+  },
+}
+
+M.comment_out_range_single_content = {
+  {
+    config = { "#", nil, nil, nil, true, false },
+    input = [[
+      | # import antigravity
+      | #
+      | # def hello():
+      | #     print('hello')
+      | #
+      | #     print('world')
+    ]],
+    output = [[
+      | import antigravity
+      |
+      | def hello():
+      |     print('hello')
+      |
+      |     print('world')
+    ]],
+  },
+  {
+    config = { "#", nil, nil, nil, true, false },
+    input = [[
+      | #     for i in range(42):
+      | #         x = i * i
+      | #
+      | #         # print(x)
+    ]],
+    output = [[
+      |     for i in range(42):
+      |         x = i * i
+      |
+      |         # print(x)
+    ]],
+  },
+  {
+    config = { "#", nil, nil, nil, true, false },
+    input = [[
+      |     # for i in range(42):
+      |     #     x = i * i
+      |     #
+      |     #     # print(x)
+    ]],
+    output = [[
+      |     for i in range(42):
+      |         x = i * i
+      |
+      |         # print(x)
+    ]],
+  },
+  {
+    config = { "#", nil, nil, nil, true, false },
+    input = [[
+      |     # for i in range(42):
+      |     #     x = i * i
+      |
+      |     #     # print(x)
+    ]],
+    output = [[
+      |     for i in range(42):
+      |         x = i * i
+      |
+      |         # print(x)
+    ]],
+  },
+  {
+    config = { "#", nil, nil, nil, true, false },
+    input = [[
+      |     #for i in range(42):
+      |     #    x = i * i
+      |     #
+      |     #    # print(x)
+    ]],
+    output = [[
+      |     for i in range(42):
+      |         x = i * i
+      |
+      |         # print(x)
+    ]],
+  },
+  {
+    config = { "#", nil, nil, nil, true, false },
+    input = [[
+      |     # for i in range(42):
+      |           # x = i * i
+      |
+      |           # # print(x)
+    ]],
+    output = [[
+      |     for i in range(42):
+      |         x = i * i
+      |
+      |         # print(x)
+    ]],
+  },
+  {
+    config = { "#", nil, nil, nil, true, false },
+    input = [[
+      |     # for i in range(42):
+      |           # x = i * i
+      |           #
+      |           # # print(x)
+    ]],
+    output = [[
+      |     for i in range(42):
+      |         x = i * i
+      |
+      |         # print(x)
+    ]],
+  },
+  {
+    config = { "#", nil, nil, nil, true, false },
+    input = [[
+      |     #for i in range(42):
+      |         #x = i * i
+      |
+      |         ## print(x)
+    ]],
+    output = [[
+      |     for i in range(42):
+      |         x = i * i
+      |
+      |         # print(x)
+    ]],
+  },
+}
+
+M.comment_in_range_content = {
+
+}
+
+M.comment_out_range_content = {
+
+}
+
+return M


### PR DESCRIPTION
- Add unit testing engine for comment_*_content functions
- Add test cases for comment_*_range_single_content

## Usage

To run the tests, ensure that the `plenary.nvim` plugin is installed and then:

```bash
cd lua
nvim --headless -c "PlenaryBustedDirectory test/"
```

This test engine is designed for the pure functions `comment_*_content`. Test cases may be specified in one of the tables in `test_cases.lua`. For example:

```lua
M.comment_in_range_single_content = {
  {
    config = { "#", nil, nil, nil, true, false },
    input = [[
      |     for i in range(42):
      |         x = i * i
      |
      |         # print(x)
    ]],
    output = [[
      |     # for i in range(42):
      |     #     x = i * i
      |     #
      |     #     # print(x)
    ]],
  },

  -- Other test cases...

}
```

Which is a test for the configuration:

```lua
ignore_whitespace = false
use_consistent_indentation = true
```

Tests for other configurations still need to be added.

---

## Test log

<details>

<summary>Current test results</summary>

```lua
λ nvim --headless -c "PlenaryBustedDirectory test/"
Starting...Scheduling: test/kommentary_spec.lua

========================================
Testing:        .../kommentary/lua/test/kommentary_spec.lua
Success ||      comment in range single (#1)
Success ||      comment in then out range single (#1)
Success ||      comment in range single (#2)
Fail    ||      comment in then out range single (#2)
            .../kommentary/lua/test/kommentary_spec.lua:37: Expected objects to be the same.
            Passed in:
            (table: 0x41ddc9e8) {
              [1] = '    for i in range(42):'
              [2] = '        x = i * i'
             *[3] = '    '
              [4] = '        # print(x)' }
            Expected:
            (table: 0x4034b758) {
              [1] = '    for i in range(42):'
              [2] = '        x = i * i'
             *[3] = ''
              [4] = '        # print(x)' }

            stack traceback:
                .../kommentary/lua/test/kommentary_spec.lua:37: in function <.../kommentary/lua/test/kommentary_spec.lua:36>

Success ||      comment out range single (#1)
Success ||      comment out range single (#2)
Fail    ||      comment out range single (#3)
            .../kommentary/lua/test/kommentary_spec.lua:30: Expected objects to be the same.
            Passed in:
            (table: 0x41b29b88) {
              [1] = '    for i in range(42):'
              [2] = '        x = i * i'
             *[3] = '    '
              [4] = '        # print(x)' }
            Expected:
            (table: 0x41b29b60) {
              [1] = '    for i in range(42):'
              [2] = '        x = i * i'
             *[3] = ''
              [4] = '        # print(x)' }

            stack traceback:
                .../kommentary/lua/test/kommentary_spec.lua:30: in function <.../kommentary/lua/test/kommentary_spec.lua:29>

Success ||      comment out range single (#4)
Fail    ||      comment out range single (#5)
            .../kommentary/lua/test/kommentary_spec.lua:30: Expected objects to be the same.
            Passed in:
            (table: 0x4018e9e0) {
              [1] = '    for i in range(42):'
             *[2] = '       x = i * i'
              [3] = '    '
              [4] = '       # print(x)' }
            Expected:
            (table: 0x4018e8b8) {
              [1] = '    for i in range(42):'
             *[2] = '        x = i * i'
              [3] = ''
              [4] = '        # print(x)' }

            stack traceback:
                .../kommentary/lua/test/kommentary_spec.lua:30: in function <.../kommentary/lua/test/kommentary_spec.lua:29>

Fail    ||      comment out range single (#6)
            .../kommentary/lua/test/kommentary_spec.lua:30: Expected objects to be the same.
            Passed in:
            (table: 0x41de5c48) {
              [1] = '    for i in range(42):'
             *[2] = '          x = i * i'
              [3] = ''
              [4] = '          # print(x)' }
            Expected:
            (table: 0x4025a608) {
              [1] = '    for i in range(42):'
             *[2] = '        x = i * i'
              [3] = ''
              [4] = '        # print(x)' }

            stack traceback:
                .../kommentary/lua/test/kommentary_spec.lua:30: in function <.../kommentary/lua/test/kommentary_spec.lua:29>

Fail    ||      comment out range single (#7)
            .../kommentary/lua/test/kommentary_spec.lua:30: Expected objects to be the same.
            Passed in:
            (table: 0x41b32640) {
              [1] = '    for i in range(42):'
             *[2] = '          x = i * i'
              [3] = '          '
              [4] = '          # print(x)' }
            Expected:
            (table: 0x41b32580) {
              [1] = '    for i in range(42):'
             *[2] = '        x = i * i'
              [3] = ''
              [4] = '        # print(x)' }

            stack traceback:
                .../kommentary/lua/test/kommentary_spec.lua:30: in function <.../kommentary/lua/test/kommentary_spec.lua:29>

Success ||      comment out range single (#8)

Success:        7
Failed :        5
Errors :        0
========================================
Tests Failed. Exit: 1
```

</details>
  