### PR TITLE
fix: index will be nil when line is an empty string

### DIFF
--- a/lua/kommentary/util.lua
+++ b/lua/kommentary/util.lua
@@ -41,14 +41,13 @@ Insert prefix at index.
 @treturn string String with prefix at index
 ]]
 function M.insert_at_index(line, prefix, index)
+    --[[ If the index is lower than 1 or nil, set it to 1 ]]
+    index = (index == nil or index < 0) and 1 or index
     --[[ If the line is empty, just return the prefix with the appropriate
     amount of whitespace in front of it ]]
     if M.is_empty(line) then
         return string.rep(' ', index-1) .. vim.trim(prefix)
     end
-    --[[ If the index is lower than 1 or nil, set it to 1 ]]
-    index = index == nil and 1 or index
-    index = index < 0 and 1 or index
     return string.sub(line, 0, index-1) .. prefix .. string.sub(line, index, #line)
 end
 


### PR DESCRIPTION
### Reproduce
1. Use config:
```lua
require('kommentary.config').configure_language("default", {
  prefer_single_line_comments = true,
  use_consistent_indentation = false,
  ignore_whitespace = false
})
```
2. Edit `test.lua`
```lua
local a = 1

print(a)
```
3. Select and comment all lines: `<Leader>ci`

### error

```
E5108: Error executing lua ...ite/pack/packer/start/kommentary/lua/kommentary/util.lua:48: attempt to perform arithmetic on local 'ind
ex' (a nil value)
stack traceback:
        ...ite/pack/packer/start/kommentary/lua/kommentary/util.lua:48: in function 'insert_at_index'
        ...ck/packer/start/kommentary/lua/kommentary/kommentary.lua:227: in function 'comment_in_range_single_content'
        ...ck/packer/start/kommentary/lua/kommentary/kommentary.lua:176: in function 'comment_in_range_single'
        ...ack/packer/start/kommentary/lua/kommentary/callbacks.lua:12: in function 'callback'
        ...ite/pack/packer/start/kommentary/lua/kommentary/init.lua:77: in function <...ite/pack/packer/start/kommentary/lua/kommentar
y/init.lua:74>
        ...ite/pack/packer/start/kommentary/lua/kommentary/init.lua:56: in function <...ite/pack/packer/start/kommentary/lua/kommentar
y/init.lua:37>
```