### PR TITLE
fix: skip Non-modifiable buffers

### DIFF
--- a/lua/kommentary/init.lua
+++ b/lua/kommentary/init.lua
@@ -35,6 +35,9 @@ will do one of two things -
     comment out and not return anything.
 ]]
 function M.go(...)
+    if not vim.bo.modifiable then
+      return
+    end
     local args = {...}
     --[[ The first argument passed to this function represents one of 3 possible
     contexts in which this function can be called - linewise, motion or visual. The


### PR DESCRIPTION
### Reproduce

1. `<Leader>ci` in Non-modifiable, eg 'nvim-tree'...

---

My key mapping is: `<Leader>/`, I would subconsciously press...