### PR TITLE
Support hook_function in default config

### DIFF
--- a/lua/kommentary/config.lua
+++ b/lua/kommentary/config.lua
@@ -302,18 +302,20 @@ function M.get_config(filetype)
     if filetype == 0 then
         filetype = vim.bo.filetype
     end
+
     local result = nil
     if M.has_filetype(filetype) then
-        hook = M.config[filetype][7]
-        if hook ~= nil then
-            hook()
-        end
         result = {unpack(M.config[filetype])}
     else
         --[[ We can't get the commentstring for a filetype different from the
         current buffer, so in that case always return the default ]]
         result = filetype == vim.bo.filetype
             and M.config_from_commentstring(vim.bo.commentstring) or M.get_default_config()
+    end
+
+    local hook = result[7]
+    if hook ~= nil then
+        hook()
     end
     -- Fill in missing or "default" fields
     for i = 1,6,1 do

--- a/lua/kommentary/config.lua
+++ b/lua/kommentary/config.lua
@@ -313,16 +313,18 @@ function M.get_config(filetype)
             and M.config_from_commentstring(vim.bo.commentstring) or M.get_default_config()
     end
 
-    local hook = result[7]
-    if hook ~= nil then
-        hook()
-    end
     -- Fill in missing or "default" fields
-    for i = 1,6,1 do
+    for i = 1,7,1 do
         if result[i] == "default" or result[i] == nil then
             result[i] = M.get_default_config()[i]
         end
     end
+
+    local hook = result[7]
+    if hook ~= nil then
+        hook()
+    end
+
     if result[1] == "auto" then
         result[1] = M.config_from_commentstring(vim.bo.commentstring)[1]
     end


### PR DESCRIPTION
Currently, a hook function cannot be provided in the default config, since kommentary sets the default values after calling the hook (see [this issue](https://github.com/JoosepAlviste/nvim-ts-context-commentstring/issues/19#issuecomment-916334428)). This change moves the calling of the hook function after filling in default values to the language-specific config, allowing users to specify a hook function to call by default. I did not see any changes in behaviour from this movement, however there might be some edge cases that I have not considered. If there is no major issue with this, it will make it much easier to work with https://github.com/JoosepAlviste/nvim-ts-context-commentstring
