### PR TITLE
implement kommentary_visual_singles command

### DIFF
--- a/lua/kommentary/callbacks.lua
+++ b/lua/kommentary/callbacks.lua
@@ -24,4 +24,17 @@ function M.decrease_comment_level(line_number_start, line_number_end, _)
     kommentary.comment_out_range(line_number_start, line_number_end, config.get_config(0))
 end
 
+function M.multicomment_single(line_number_start, line_number_end, _)
+    local config = require('kommentary.config')
+    local kommentary = require('kommentary.kommentary')
+    if line_number_start > line_number_end then
+        line_number_start, line_number_end = line_number_end, line_number_start
+    end
+    if kommentary.is_comment(line_number_start, line_number_end, config.get_config(0)) then
+      kommentary.comment_out_range(line_number_start, line_number_end, config.get_config(0))
+    else
+      kommentary.comment_in_range_single(line_number_start, line_number_end, config.get_config(0))
+    end
+end
+
 return M

--- a/lua/kommentary/config.lua
+++ b/lua/kommentary/config.lua
@@ -98,6 +98,8 @@ function M.setup()
     M.add_keymap("n", "kommentary_motion_default", M.context.motion, { expr = true })
     M.add_keymap("n", "kommentary_line_default", M.context.line, { expr = true })
     M.add_keymap("x", "kommentary_visual_default", M.context.visual)
+    M.add_keymap("x", "kommentary_visual_singles", M.context.visual,{},
+    callbacks.multicomment_single)
     -- Increase comment level
     M.add_keymap("n", "kommentary_motion_increase", M.context.motion, { expr = true },
         callbacks.increase_comment_level)


### PR DESCRIPTION
In `function M.setup()` a `<Plug>kommentary_visual_singles` command is shown as an example, but this command is not implemented. I implemented this for visual mode using a new callback. This is useful when you want to decide when use line or block comments.