### PR TITLE
feat(config): add `dosbatch` support

### DIFF
--- a/lua/kommentary/config.lua
+++ b/lua/kommentary/config.lua
@@ -48,6 +48,7 @@ M.config = {
     ["clojure"] = {";", {"(comment ", " )"}},
     ["cpp"] = {},
     ["cs"] = {},
+    ["dosbatch"] = {"REM", false},
     ["elixir"] = {"#", false, true},
     ["fennel"] = {";", false},
     ["go"] = {},


### PR DESCRIPTION
Add `dosbatch` support for security (Vim's default `::` commentstring may cause errors) and compatibility (with all versions of Windows) reasons. Here is two (the shortest) of the many justifications:

- [tldr](https://stackoverflow.com/a/12407934)
- [generalized](https://stackoverflow.com/a/12408045)